### PR TITLE
Exclude unused import and change environments count

### DIFF
--- a/icpy/ICP.py
+++ b/icpy/ICP.py
@@ -4,7 +4,6 @@ from collections import namedtuple
 import numpy as np
 import scipy.stats
 import sklearn.linear_model
-from sklearn.linear_model import RandomizedLasso
 
 
 def all_parent_sets(S, max_num_parents):

--- a/icpy/ICP.py
+++ b/icpy/ICP.py
@@ -20,7 +20,8 @@ def f_test(x1, x2):
 
 
 def test_plausible_parent_set(X, y, z):
-    n_e = np.max(z) + 1
+    n_e = len(np.unique(z))
+    environments = np.unique(z)
     lm = sklearn.linear_model.LinearRegression(fit_intercept=False)
     X_with_intercept = np.hstack((X, np.ones((X.shape[0], 1))))
     lm.fit(X_with_intercept, y)
@@ -31,7 +32,7 @@ def test_plausible_parent_set(X, y, z):
                                               equal_var=False).pvalue,
                         f_test(residuals[np.equal(z, e)],
                                residuals[np.logical_not(np.equal(z, e))]))
-                for e in range(n_e)]) * n_e
+                for e in environments]) * n_e
 
 
 def preselect_parents(X, y, n):


### PR DESCRIPTION
Exclude the `RandomizedLasso` import, since it's unused and it also raises ImportError in newer sklearn versions.

Also, it changes the way `n_e` is calculated for the Bonferroni correction and creates a new variable to iterate in the environments, making it possible to have any logic for the environments labels, since I was testing with an example where the environments were identified by its noise, being `0.1 and 1`, from the [Invariant Risk Minimization](https://arxiv.org/abs/1907.02893v1) paper. 